### PR TITLE
feat: axios interceptor 설정

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,0 +1,48 @@
+import axios from "axios";
+
+const API_URL = process.env.REACT_APP_API_BASE_URL;
+
+const api = axios.create({
+  baseURL: API_URL,
+  withCredentials: true,
+});
+
+api.interceptors.request.use(
+  (config) => config,
+  (error) => Promise.reject(error)
+);
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        await axios.post(
+          `${API_URL}/auth/reissue`,
+          {},
+          {
+            withCredentials: true,
+          }
+        );
+        return api(originalRequest);
+      } catch (refreshError) {
+        alert("로그인이 만료되었습니다. 다시 로그인해주세요.");
+        window.location.href = "/login";
+        return Promise.reject(refreshError);
+      }
+    }
+
+    if ([401, 403].includes(error.response?.status)) {
+      if (window.location.pathname !== "/") {
+        alert("접근 권한이 없습니다. 로그인 후 이용해주세요.");
+        window.location.href = "/login";
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+//


### PR DESCRIPTION
## ✨ 작업 내용 개요
- HttpOnly 쿠키 기반 JWT 인증 구조에 맞춰 axios Interceptor를 설정했습니다. 
- accessToken 만료되어 401에러 발생 시 자동으로 토큰 재발급받고, 원래 요청을 실행합니다. 
- 토큰 재발급 실패시 로그인 페이지로 이동합니다. 


❗️확인해주세요
api 요청하는 코드 작성하실 때
아래처럼 api.get(...) 이런식으로 사용하면 자동으로 인증 로직 동작합니다. 
accessToken을 별도로 헤더에 넣을 필요없습니다!


```javascript
import api from '../api/api';

api.get('/user/profile')
  .then(res => console.log(res.data))
  .catch(err => console.error(err));
```



## 🛠️ 작업 사항 상세
- /api/api.js에 Axios 인스턴스를 생성하고, 요청/응답 인터셉터를 설정했습니다. 
- 요청 시 자동으로 쿠키 전송되도록 설정
- 응답 시 401에러가 발생하면 토큰 재발급 시도
- 재발급 성공시 원래 요청 자동 재시도
- 재발급 실패시 로그인 페이지로 이동

## 🔎 관련 이슈
- #5 

## 🕒 예상 리뷰 시간
- 5분

## ✅ PR Checklist
- [ ]  기능이 정확하게 동작합니다.
- [ ]  더 나은 코드에 대해서 고민해보았습니다.
- [ ]  구현한 기능에 대한 테스트를 진행했습니다.
- [ ]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ]  라벨과 리뷰어를 설정했습니다.
- [ ]  민감파일(*.yml 등) .gitignore 설정했습니다.

## 📚 참고자료
- 참고한 자료가 있으면 작성해주세요.
